### PR TITLE
API26 Oreo: Get the Project to Build and Run.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,55 @@
-*.iml
-.gradle
-/local.properties
-/.idea/workspace.xml
-/.idea/libraries
-.DS_Store
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Gradle files
+.gradle/
 build/
+
+# Android Studio Files
+*.iws
+*.iml
+*.ipr
+/.idea/workspace.xml
+.idea/gradle.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/runConfigurations.xml
+.idea/vcs.xml
+/.idea/libraries
+
+
+# OS-specific files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+*~
+.swp
+
+# Log Files
+*.log
+
+# Android Studio Navigation editor temp files
+.navigation/
+
+# Android Studio captures folder
+captures/
 /captures
-.externalNativeBuild
+
+# Eclipse project files
+.classpath
+.project
+.cproject
+.settings
+.metadata
+proguard/
+
+# Generated files
+bin/
+gen/
+
+# Signing files
+.signing/

--- a/.idea/runConfigurations/Step_1.xml
+++ b/.idea/runConfigurations/Step_1.xml
@@ -6,7 +6,6 @@
     <option name="PM_INSTALL_OPTIONS" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="specific_activity" />
-    <option name="PREFERRED_AVD" value="" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
@@ -40,12 +39,13 @@
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
     </Native>
     <Profilers>
-      <option name="ENABLE_ADVANCED_PROFILING" value="true" />
-      <option name="SUPPORT_LIB_ENABLED" value="true" />
-      <option name="INSTRUMENTATION_ENABLED" value="true" />
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
     <option name="ACTIVITY_CLASS" value="com.example.android.lifecycles.step1.ChronoActivity1" />
-    <method />
+    <method>
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+      <option name="com.android.instantApps.provision.BeforeRunTask" enabled="true" clearCache="false" clearProvisionedDevices="false" myTimestamp="1510009601189" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Step_2___ViewModel.xml
+++ b/.idea/runConfigurations/Step_2___ViewModel.xml
@@ -6,7 +6,6 @@
     <option name="PM_INSTALL_OPTIONS" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="specific_activity" />
-    <option name="PREFERRED_AVD" value="" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
@@ -40,12 +39,13 @@
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
     </Native>
     <Profilers>
-      <option name="ENABLE_ADVANCED_PROFILING" value="true" />
-      <option name="SUPPORT_LIB_ENABLED" value="true" />
-      <option name="INSTRUMENTATION_ENABLED" value="true" />
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
     <option name="ACTIVITY_CLASS" value="com.example.android.lifecycles.step2.ChronoActivity2" />
-    <method />
+    <method>
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+      <option name="com.android.instantApps.provision.BeforeRunTask" enabled="true" clearCache="false" clearProvisionedDevices="false" myTimestamp="1510009601189" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Step_3___LiveData.xml
+++ b/.idea/runConfigurations/Step_3___LiveData.xml
@@ -6,7 +6,6 @@
     <option name="PM_INSTALL_OPTIONS" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="specific_activity" />
-    <option name="PREFERRED_AVD" value="" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
@@ -40,12 +39,13 @@
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
     </Native>
     <Profilers>
-      <option name="ENABLE_ADVANCED_PROFILING" value="true" />
-      <option name="SUPPORT_LIB_ENABLED" value="true" />
-      <option name="INSTRUMENTATION_ENABLED" value="true" />
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
     <option name="ACTIVITY_CLASS" value="com.example.android.lifecycles.step3.ChronoActivity3" />
-    <method />
+    <method>
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+      <option name="com.android.instantApps.provision.BeforeRunTask" enabled="true" clearCache="false" clearProvisionedDevices="false" myTimestamp="1510009601189" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Step_3___LiveData_solution.xml
+++ b/.idea/runConfigurations/Step_3___LiveData_solution.xml
@@ -6,7 +6,6 @@
     <option name="PM_INSTALL_OPTIONS" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="specific_activity" />
-    <option name="PREFERRED_AVD" value="" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
@@ -40,12 +39,13 @@
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
     </Native>
     <Profilers>
-      <option name="ENABLE_ADVANCED_PROFILING" value="true" />
-      <option name="SUPPORT_LIB_ENABLED" value="true" />
-      <option name="INSTRUMENTATION_ENABLED" value="true" />
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
     <option name="ACTIVITY_CLASS" value="com.example.android.lifecycles.step3_solution.ChronoActivity3" />
-    <method />
+    <method>
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+      <option name="com.android.instantApps.provision.BeforeRunTask" enabled="true" clearCache="false" clearProvisionedDevices="false" myTimestamp="1510009601189" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Step_4___Lifecycle_provider.xml
+++ b/.idea/runConfigurations/Step_4___Lifecycle_provider.xml
@@ -6,7 +6,6 @@
     <option name="PM_INSTALL_OPTIONS" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="specific_activity" />
-    <option name="PREFERRED_AVD" value="" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
@@ -40,12 +39,13 @@
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
     </Native>
     <Profilers>
-      <option name="ENABLE_ADVANCED_PROFILING" value="true" />
-      <option name="SUPPORT_LIB_ENABLED" value="true" />
-      <option name="INSTRUMENTATION_ENABLED" value="true" />
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
     <option name="ACTIVITY_CLASS" value="com.example.android.lifecycles.step4.LocationActivity" />
-    <method />
+    <method>
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+      <option name="com.android.instantApps.provision.BeforeRunTask" enabled="true" clearCache="false" clearProvisionedDevices="false" myTimestamp="1510009601189" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Step_4___Lifecycle_provider_solution.xml
+++ b/.idea/runConfigurations/Step_4___Lifecycle_provider_solution.xml
@@ -6,7 +6,6 @@
     <option name="PM_INSTALL_OPTIONS" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="specific_activity" />
-    <option name="PREFERRED_AVD" value="" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
@@ -40,12 +39,13 @@
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
     </Native>
     <Profilers>
-      <option name="ENABLE_ADVANCED_PROFILING" value="true" />
-      <option name="SUPPORT_LIB_ENABLED" value="true" />
-      <option name="INSTRUMENTATION_ENABLED" value="true" />
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
     <option name="ACTIVITY_CLASS" value="com.example.android.lifecycles.step4_solution.LocationActivity" />
-    <method />
+    <method>
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+      <option name="com.android.instantApps.provision.BeforeRunTask" enabled="true" clearCache="false" clearProvisionedDevices="false" myTimestamp="1510009601189" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Step_5___Sharing_VMs.xml
+++ b/.idea/runConfigurations/Step_5___Sharing_VMs.xml
@@ -6,7 +6,6 @@
     <option name="PM_INSTALL_OPTIONS" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="specific_activity" />
-    <option name="PREFERRED_AVD" value="" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
@@ -40,12 +39,13 @@
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
     </Native>
     <Profilers>
-      <option name="ENABLE_ADVANCED_PROFILING" value="true" />
-      <option name="SUPPORT_LIB_ENABLED" value="true" />
-      <option name="INSTRUMENTATION_ENABLED" value="true" />
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
     <option name="ACTIVITY_CLASS" value="com.example.android.lifecycles.step5.Activity_step5" />
-    <method />
+    <method>
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+      <option name="com.android.instantApps.provision.BeforeRunTask" enabled="true" clearCache="false" clearProvisionedDevices="false" myTimestamp="1510009601189" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Step_5___Sharing_VMs_solution.xml
+++ b/.idea/runConfigurations/Step_5___Sharing_VMs_solution.xml
@@ -6,7 +6,6 @@
     <option name="PM_INSTALL_OPTIONS" value="" />
     <option name="ACTIVITY_EXTRA_FLAGS" value="" />
     <option name="MODE" value="specific_activity" />
-    <option name="PREFERRED_AVD" value="" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
     <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
@@ -40,12 +39,13 @@
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
     </Native>
     <Profilers>
-      <option name="ENABLE_ADVANCED_PROFILING" value="true" />
-      <option name="SUPPORT_LIB_ENABLED" value="true" />
-      <option name="INSTRUMENTATION_ENABLED" value="true" />
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
     </Profilers>
     <option name="DEEP_LINK" value="" />
     <option name="ACTIVITY_CLASS" value="com.example.android.lifecycles.step5_solution.Activity_step5" />
-    <method />
+    <method>
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+      <option name="com.android.instantApps.provision.BeforeRunTask" enabled="true" clearCache="false" clearProvisionedDevices="false" myTimestamp="1510009601189" />
+    </method>
   </configuration>
 </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,15 +17,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
     defaultConfig {
         applicationId 'com.example.android.codelabs.lifecycle'
-        minSdkVersion 21
-        targetSdkVersion 25
+        minSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -42,15 +43,15 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:' + rootProject.espressoVersion, {
+    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:' + rootProject.supportLibVersion;
-    compile 'com.android.support:cardview-v7:' + rootProject.supportLibVersion;
-    compile 'com.android.support:recyclerview-v7:' + rootProject.supportLibVersion;
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:cardview-v7:26.1.0'
+    compile 'com.android.support:recyclerview-v7:26.1.0'
     testCompile 'junit:junit:4.12'
-    compile 'android.arch.lifecycle:extensions:' + rootProject.archLifecycleVersion;
-    compile 'android.arch.persistence.room:runtime:' + rootProject.archRoomVersion;
-    annotationProcessor 'android.arch.lifecycle:compiler:' + rootProject.archLifecycleVersion;
-    annotationProcessor 'android.arch.persistence.room:compiler:' + rootProject.archRoomVersion;
+    compile 'android.arch.lifecycle:extensions:1.0.0'
+    compile 'android.arch.persistence.room:runtime:1.0.0'
+    annotationProcessor 'android.arch.lifecycle:compiler:1.0.0'
+    annotationProcessor 'android.arch.persistence.room:compiler:1.0.0'
 }

--- a/app/src/main/java/com/example/android/lifecycles/step3/ChronoActivity3.java
+++ b/app/src/main/java/com/example/android/lifecycles/step3/ChronoActivity3.java
@@ -54,5 +54,6 @@ public class ChronoActivity3 extends LifecycleActivity {
         };
 
         //TODO: observe the ViewModel's elapsed time
+        mLiveDataTimerViewModel.getElapsedTime().observe(this, elapsedTimeObserver);
     }
 }

--- a/app/src/main/java/com/example/android/lifecycles/step3/LiveDataTimerViewModel.java
+++ b/app/src/main/java/com/example/android/lifecycles/step3/LiveDataTimerViewModel.java
@@ -54,7 +54,7 @@ public class LiveDataTimerViewModel extends ViewModel {
                     public void run() {
 
                         //TODO set the new value
-
+                        mElapsedTime.setValue(newValue);
                     }
                 });
             }

--- a/app/src/main/java/com/example/android/lifecycles/step4/BoundLocationManager.java
+++ b/app/src/main/java/com/example/android/lifecycles/step4/BoundLocationManager.java
@@ -16,6 +16,9 @@
 
 package com.example.android.lifecycles.step4;
 
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.OnLifecycleEvent;
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationListener;
@@ -27,7 +30,7 @@ import android.arch.lifecycle.LifecycleRegistryOwner;
 
 
 public class BoundLocationManager {
-    public static void bindLocationListenerIn(LifecycleRegistryOwner lifecycleOwner,
+    public static void bindLocationListenerIn(LifecycleOwner lifecycleOwner,
                                               LocationListener listener, Context context) {
         new BoundLocationListener(lifecycleOwner, listener, context);
     }
@@ -38,14 +41,16 @@ public class BoundLocationManager {
         private LocationManager mLocationManager;
         private final LocationListener mListener;
 
-        public BoundLocationListener(LifecycleRegistryOwner lifecycleOwner,
+        public BoundLocationListener(LifecycleOwner lifecycleOwner,
                                      LocationListener listener, Context context) {
             mContext = context;
             mListener = listener;
             //TODO: Add lifecycle observer
+            lifecycleOwner.getLifecycle().addObserver(this);
         }
 
         //TODO: Call this on resume
+        @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
         void addLocationListener() {
             // Note: Use the Fused Location Provider from Google Play Services instead.
             // https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderApi
@@ -64,6 +69,7 @@ public class BoundLocationManager {
         }
 
         //TODO: Call this on pause
+        @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
         void removeLocationListener() {
             if (mLocationManager == null) {
                 return;

--- a/app/src/main/java/com/example/android/lifecycles/step4/LocationActivity.java
+++ b/app/src/main/java/com/example/android/lifecycles/step4/LocationActivity.java
@@ -50,7 +50,7 @@ public class LocationActivity extends LifecycleActivity {
 
     private void bindLocationListener() {
         // Changed first argument from "this" to lifecycleOwner
-        BoundLocationManager.bindLocationListenerIn((LifecycleRegistryOwner) this, mGpsListener, getApplicationContext());
+        BoundLocationManager.bindLocationListenerIn(this, mGpsListener, getApplicationContext());
     }
 
     @Override

--- a/app/src/main/java/com/example/android/lifecycles/step4/LocationActivity.java
+++ b/app/src/main/java/com/example/android/lifecycles/step4/LocationActivity.java
@@ -17,6 +17,7 @@
 package com.example.android.lifecycles.step4;
 
 import android.Manifest;
+import android.arch.lifecycle.LifecycleRegistryOwner;
 import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationListener;
@@ -48,7 +49,8 @@ public class LocationActivity extends LifecycleActivity {
     }
 
     private void bindLocationListener() {
-        BoundLocationManager.bindLocationListenerIn(this, mGpsListener, getApplicationContext());
+        // Changed first argument from "this" to lifecycleOwner
+        BoundLocationManager.bindLocationListenerIn((LifecycleRegistryOwner) this, mGpsListener, getApplicationContext());
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -42,11 +42,6 @@ task clean(type: Delete) {
 }
 
 ext {
-    buildToolsVersion = "25.0.2"
-    supportLibVersion = "25.3.1"
     runnerVersion = "0.5"
     rulesVersion = "0.5"
-    espressoVersion = "2.2.2"
-    archLifecycleVersion = "1.0.0-alpha1"
-    archRoomVersion = "1.0.0-alpha1"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,22 +1,6 @@
-#
-# Copyright 2017, The Android Open Source Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-#Mon Feb 20 17:11:12 GMT 2017
+#Mon Nov 06 22:10:02 GMT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Step 1 of the Code Lab is not building, as is. Making these changes, I got it to build and run on the Emulator API 26.

Moving the versions of the dependencies into the `app/build.gradle` file now gives you updates when a new version is available in Android Studio, so it's more maintainable than having them defined in the top level `build.gradle`, for a single module project.

I went a bit overboard on the `.gitignore`, as I put in my version.