### PR TITLE
Fixit cancel timer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,11 +17,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId 'com.example.android.codelabs.lifecycle'
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -43,7 +43,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "androidx.cardview:cardview:$cardViewVersion"
     implementation "androidx.legacy:legacy-support-v4:$legacySupportVersion"
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
     implementation "androidx.room:room-runtime:$roomVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
             android:label="LC Step1">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <activity
@@ -83,8 +84,6 @@
             android:label="LC Step5 Sol">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <activity
@@ -92,8 +91,6 @@
             android:label="LC Step6">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <activity
@@ -101,8 +98,6 @@
             android:label="LC Step6 Sol">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/example/android/lifecycles/step2/ChronoActivity2.java
+++ b/app/src/main/java/com/example/android/lifecycles/step2/ChronoActivity2.java
@@ -16,10 +16,11 @@
 
 package com.example.android.lifecycles.step2;
 
-import androidx.lifecycle.ViewModelProviders;
+
 import android.os.Bundle;
 import android.os.SystemClock;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
 import android.widget.Chronometer;
 
 import com.example.android.codelabs.lifecycle.R;
@@ -33,7 +34,7 @@ public class ChronoActivity2 extends AppCompatActivity {
 
         // The ViewModelStore provides a new ViewModel or one previously created.
         ChronometerViewModel chronometerViewModel
-                = ViewModelProviders.of(this).get(ChronometerViewModel.class);
+                = new ViewModelProvider(this).get(ChronometerViewModel.class);
 
         // Get the chronometer reference
         Chronometer chronometer = findViewById(R.id.chronometer);

--- a/app/src/main/java/com/example/android/lifecycles/step2/ChronoActivity2.java
+++ b/app/src/main/java/com/example/android/lifecycles/step2/ChronoActivity2.java
@@ -16,7 +16,6 @@
 
 package com.example.android.lifecycles.step2;
 
-
 import android.os.Bundle;
 import android.os.SystemClock;
 import androidx.appcompat.app.AppCompatActivity;

--- a/app/src/main/java/com/example/android/lifecycles/step3/ChronoActivity3.java
+++ b/app/src/main/java/com/example/android/lifecycles/step3/ChronoActivity3.java
@@ -17,7 +17,7 @@
 package com.example.android.lifecycles.step3;
 
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -37,7 +37,7 @@ public class ChronoActivity3 extends AppCompatActivity {
 
         setContentView(R.layout.chrono_activity_3);
 
-        mLiveDataTimerViewModel = ViewModelProviders.of(this).get(LiveDataTimerViewModel.class);
+        mLiveDataTimerViewModel = new ViewModelProvider(this).get(LiveDataTimerViewModel.class);
 
         subscribe();
     }

--- a/app/src/main/java/com/example/android/lifecycles/step3/LiveDataTimerViewModel.java
+++ b/app/src/main/java/com/example/android/lifecycles/step3/LiveDataTimerViewModel.java
@@ -34,10 +34,11 @@ public class LiveDataTimerViewModel extends ViewModel {
     private MutableLiveData<Long> mElapsedTime = new MutableLiveData<>();
 
     private long mInitialTime;
+    private final Timer timer;
 
     public LiveDataTimerViewModel() {
         mInitialTime = SystemClock.elapsedRealtime();
-        Timer timer = new Timer();
+        timer = new Timer();
 
         // Update the elapsed time every second.
         timer.scheduleAtFixedRate(new TimerTask() {
@@ -55,5 +56,11 @@ public class LiveDataTimerViewModel extends ViewModel {
     @SuppressWarnings("unused")  // Will be used when step is completed
     public LiveData<Long> getElapsedTime() {
         return mElapsedTime;
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        timer.cancel();
     }
 }

--- a/app/src/main/java/com/example/android/lifecycles/step3_solution/ChronoActivity3.java
+++ b/app/src/main/java/com/example/android/lifecycles/step3_solution/ChronoActivity3.java
@@ -17,7 +17,7 @@
 package com.example.android.lifecycles.step3_solution;
 
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -36,7 +36,7 @@ public class ChronoActivity3 extends AppCompatActivity {
 
         setContentView(R.layout.chrono_activity_3);
 
-        mLiveDataTimerViewModel = ViewModelProviders.of(this).get(LiveDataTimerViewModel.class);
+        mLiveDataTimerViewModel = new ViewModelProvider(this).get(LiveDataTimerViewModel.class);
 
         subscribe();
     }

--- a/app/src/main/java/com/example/android/lifecycles/step3_solution/LiveDataTimerViewModel.java
+++ b/app/src/main/java/com/example/android/lifecycles/step3_solution/LiveDataTimerViewModel.java
@@ -34,10 +34,11 @@ public class LiveDataTimerViewModel extends ViewModel {
     private MutableLiveData<Long> mElapsedTime = new MutableLiveData<>();
 
     private long mInitialTime;
+    private final Timer timer;
 
     public LiveDataTimerViewModel() {
         mInitialTime = SystemClock.elapsedRealtime();
-        Timer timer = new Timer();
+        timer = new Timer();
 
         // Update the elapsed time every second.
         timer.scheduleAtFixedRate(new TimerTask() {
@@ -53,5 +54,11 @@ public class LiveDataTimerViewModel extends ViewModel {
 
     public LiveData<Long> getElapsedTime() {
         return mElapsedTime;
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        timer.cancel();
     }
 }

--- a/app/src/main/java/com/example/android/lifecycles/step4/LocationActivity.java
+++ b/app/src/main/java/com/example/android/lifecycles/step4/LocationActivity.java
@@ -39,7 +39,7 @@ public class LocationActivity extends AppCompatActivity {
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
             @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (grantResults[0] == PackageManager.PERMISSION_GRANTED
+        if (grantResults.length > 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED
                 && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
             bindLocationListener();
         } else {

--- a/app/src/main/java/com/example/android/lifecycles/step4_solution/LocationActivity.java
+++ b/app/src/main/java/com/example/android/lifecycles/step4_solution/LocationActivity.java
@@ -39,7 +39,7 @@ public class LocationActivity extends AppCompatActivity {
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
             @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (grantResults[0] == PackageManager.PERMISSION_GRANTED
+        if (grantResults.length > 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED
                 && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
             bindLocationListener();
         } else {

--- a/app/src/main/java/com/example/android/lifecycles/step5_solution/Fragment_step5.java
+++ b/app/src/main/java/com/example/android/lifecycles/step5_solution/Fragment_step5.java
@@ -34,8 +34,6 @@ import android.widget.SeekBar;
 import com.example.android.codelabs.lifecycle.R;
 import com.example.android.lifecycles.step5.SeekBarViewModel;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * Shows a SeekBar that is synced with a value in a ViewModel.
  */
@@ -52,7 +50,7 @@ public class Fragment_step5 extends Fragment {
         View root = inflater.inflate(R.layout.fragment_step5, container, false);
         mSeekBar = root.findViewById(R.id.seekBar);
 
-        mSeekBarViewModel = new ViewModelProvider(requireNonNull(getActivity())).get(SeekBarViewModel.class);
+        mSeekBarViewModel = new ViewModelProvider(requireActivity()).get(SeekBarViewModel.class);
 
         subscribeSeekBar();
 
@@ -80,7 +78,7 @@ public class Fragment_step5 extends Fragment {
 
         // Update the SeekBar when the ViewModel is changed.
         mSeekBarViewModel.seekbarValue.observe(
-                requireNonNull(getActivity()), new Observer<Integer>() {
+                requireActivity(), new Observer<Integer>() {
                     @Override
                     public void onChanged(@Nullable Integer value) {
                         if (value != null) {

--- a/app/src/main/java/com/example/android/lifecycles/step5_solution/Fragment_step5.java
+++ b/app/src/main/java/com/example/android/lifecycles/step5_solution/Fragment_step5.java
@@ -18,10 +18,13 @@ package com.example.android.lifecycles.step5_solution;
 
 
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
+
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -30,6 +33,8 @@ import android.widget.SeekBar;
 
 import com.example.android.codelabs.lifecycle.R;
 import com.example.android.lifecycles.step5.SeekBarViewModel;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Shows a SeekBar that is synced with a value in a ViewModel.
@@ -47,7 +52,7 @@ public class Fragment_step5 extends Fragment {
         View root = inflater.inflate(R.layout.fragment_step5, container, false);
         mSeekBar = root.findViewById(R.id.seekBar);
 
-        mSeekBarViewModel = ViewModelProviders.of(getActivity()).get(SeekBarViewModel.class);
+        mSeekBarViewModel = new ViewModelProvider(requireNonNull(getActivity())).get(SeekBarViewModel.class);
 
         subscribeSeekBar();
 
@@ -74,13 +79,14 @@ public class Fragment_step5 extends Fragment {
         });
 
         // Update the SeekBar when the ViewModel is changed.
-        mSeekBarViewModel.seekbarValue.observe(getActivity(), new Observer<Integer>() {
-            @Override
-            public void onChanged(@Nullable Integer value) {
-                if (value != null) {
-                    mSeekBar.setProgress(value);
-                }
-            }
-        });
+        mSeekBarViewModel.seekbarValue.observe(
+                requireNonNull(getActivity()), new Observer<Integer>() {
+                    @Override
+                    public void onChanged(@Nullable Integer value) {
+                        if (value != null) {
+                            mSeekBar.setProgress(value);
+                        }
+                    }
+                });
     }
 }

--- a/app/src/main/java/com/example/android/lifecycles/step6/SavedStateActivity.java
+++ b/app/src/main/java/com/example/android/lifecycles/step6/SavedStateActivity.java
@@ -22,11 +22,11 @@ import android.view.View.OnClickListener;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import com.example.android.codelabs.lifecycle.R;
-
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
+
+import com.example.android.codelabs.lifecycle.R;
 
 /**
  * Shows a simple form with a button and displays the value of a property in a ViewModel.
@@ -40,9 +40,9 @@ public class SavedStateActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.saved_state_activity);
 
-        // TODO: Pass a SavedStateVMFactory so you can use SavedStateHandle
-        // Obtain ViewModel
-        mSavedStateViewModel = ViewModelProviders.of(this).get(SavedStateViewModel.class);
+
+        // Obtain the ViewModel
+        mSavedStateViewModel = new ViewModelProvider(this).get(SavedStateViewModel.class);
 
         // Show the ViewModel property's value in a TextView
         mSavedStateViewModel.getName().observe(this, new Observer<String>() {

--- a/app/src/main/java/com/example/android/lifecycles/step6/SavedStateActivity.java
+++ b/app/src/main/java/com/example/android/lifecycles/step6/SavedStateActivity.java
@@ -40,7 +40,6 @@ public class SavedStateActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.saved_state_activity);
 
-
         // Obtain the ViewModel
         mSavedStateViewModel = new ViewModelProvider(this).get(SavedStateViewModel.class);
 
@@ -50,7 +49,6 @@ public class SavedStateActivity extends AppCompatActivity {
             public void onChanged(String savedString) {
                 ((TextView)findViewById(R.id.saved_vm_tv))
                         .setText(getString(R.string.saved_in_vm, savedString));
-
             }
         });
 

--- a/app/src/main/java/com/example/android/lifecycles/step6_solution/SavedStateActivity.java
+++ b/app/src/main/java/com/example/android/lifecycles/step6_solution/SavedStateActivity.java
@@ -26,8 +26,7 @@ import com.example.android.codelabs.lifecycle.R;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.SavedStateVMFactory;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 
 /**
  * Shows a simple form with a button and displays the value of a property in a ViewModel.
@@ -41,10 +40,8 @@ public class SavedStateActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.saved_state_activity);
 
-        // Obtain the ViewModel, passing in an optional
-        // SavedStateVMFactory so that you can use SavedStateHandle
-        mSavedStateViewModel = ViewModelProviders.of(this, new SavedStateVMFactory(this))
-                .get(SavedStateViewModel.class);
+        // Obtain the ViewModel
+        mSavedStateViewModel = new ViewModelProvider(this).get(SavedStateViewModel.class);
 
         // Show the ViewModel property's value in a TextView
         mSavedStateViewModel.getName().observe(this, new Observer<String>() {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -41,15 +41,15 @@ task clean(type: Delete) {
 }
 
 ext {
-    appCompatVersion = '1.0.2'
+    appCompatVersion = '1.1.0'
     cardViewVersion = '1.0.0'
     espressoVersion = '3.1.0'
     junitVersion = '4.12'
     legacySupportVersion = '1.0.0'
     lifecycleVersion = '2.0.0'
     recyclerViewVersion = '1.0.0'
-    roomVersion = '2.0.0'
+    roomVersion = '2.2.1'
     constraintLayoutVersion = '1.1.3'
-    lifecycleExtensionsVersion = '2.1.0-alpha02'
-    savedStateVersion = '1.0.0-alpha01'
+    lifecycleExtensionsVersion = '2.2.0-rc02'
+    savedStateVersion = '1.0.0-rc02'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-#Wed Feb 20 17:56:53 CET 2019
+#Thu Nov 07 15:52:13 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Cancelling the timer in onCleared. (See https://github.com/googlecodelabs/android-lifecycles/issues/59 and https://github.com/googlecodelabs/android-lifecycles/issues/65)

Doesn't seem strictly necessary as per docs, but I don't think it will hurt. According to the docs:

"After the last live reference to a Timer object goes away and all outstanding tasks have completed execution, the timer's task execution thread terminates gracefully (and becomes subject to garbage collection). However, this can take arbitrarily long to occur. By default, the task execution thread does not run as a daemon thread, so it is capable of keeping an application from terminating. If a caller wants to terminate a timer's task execution thread rapidly, the caller should invoke the timer's cancel method."

https://developer.android.com/reference/java/util/Timer

