### PR TITLE
Cancel the timer in step 3

### DIFF
--- a/app/src/main/java/com/example/android/lifecycles/step3/LiveDataTimerViewModel.java
+++ b/app/src/main/java/com/example/android/lifecycles/step3/LiveDataTimerViewModel.java
@@ -34,10 +34,11 @@ public class LiveDataTimerViewModel extends ViewModel {
     private MutableLiveData<Long> mElapsedTime = new MutableLiveData<>();
 
     private long mInitialTime;
+    private final Timer timer;
 
     public LiveDataTimerViewModel() {
         mInitialTime = SystemClock.elapsedRealtime();
-        Timer timer = new Timer();
+        timer = new Timer();
 
         // Update the elapsed time every second.
         timer.scheduleAtFixedRate(new TimerTask() {
@@ -55,5 +56,11 @@ public class LiveDataTimerViewModel extends ViewModel {
     @SuppressWarnings("unused")  // Will be used when step is completed
     public LiveData<Long> getElapsedTime() {
         return mElapsedTime;
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        timer.cancel();
     }
 }

--- a/app/src/main/java/com/example/android/lifecycles/step3_solution/LiveDataTimerViewModel.java
+++ b/app/src/main/java/com/example/android/lifecycles/step3_solution/LiveDataTimerViewModel.java
@@ -34,10 +34,11 @@ public class LiveDataTimerViewModel extends ViewModel {
     private MutableLiveData<Long> mElapsedTime = new MutableLiveData<>();
 
     private long mInitialTime;
+    private final Timer timer;
 
     public LiveDataTimerViewModel() {
         mInitialTime = SystemClock.elapsedRealtime();
-        Timer timer = new Timer();
+        timer = new Timer();
 
         // Update the elapsed time every second.
         timer.scheduleAtFixedRate(new TimerTask() {
@@ -53,5 +54,11 @@ public class LiveDataTimerViewModel extends ViewModel {
 
     public LiveData<Long> getElapsedTime() {
         return mElapsedTime;
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        timer.cancel();
     }
 }


### PR DESCRIPTION
Cancelling the timer in onCleared. (See #59 and #65)

Doesn't seem strictly necessary as per docs, but I don't think it will hurt. According to the docs:

"After the last live reference to a Timer object goes away and all outstanding tasks have completed execution, the timer's task execution thread terminates gracefully (and becomes subject to garbage collection). However, this can take arbitrarily long to occur. By default, the task execution thread does not run as a daemon thread, so it is capable of keeping an application from terminating. If a caller wants to terminate a timer's task execution thread rapidly, the caller should invoke the timer's cancel method."

https://developer.android.com/reference/java/util/Timer